### PR TITLE
Add Player Jumping

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -14,6 +14,14 @@ config/name="Space Tap"
 config/features=PackedStringArray("4.1", "GL Compatibility")
 config/icon="res://icon.svg"
 
+[input]
+
+jump={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":32,"key_label":0,"unicode":32,"echo":false,"script":null)
+]
+}
+
 [rendering]
 
 renderer/rendering_method="gl_compatibility"

--- a/scenes/PlayerShip.tscn
+++ b/scenes/PlayerShip.tscn
@@ -1,8 +1,14 @@
-[gd_scene load_steps=2 format=3 uid="uid://cbo0qhc8xyn3p"]
+[gd_scene load_steps=3 format=3 uid="uid://cbo0qhc8xyn3p"]
 
 [ext_resource type="Texture2D" uid="uid://c1iix6cikga5k" path="res://assets/images/playerShip3_red.png" id="1_f5d1k"]
+[ext_resource type="Script" path="res://scripts/player.gd" id="1_pw78o"]
 
-[node name="PlayerShipRoot" type="Node2D"]
+[node name="PlayerShipRoot" type="RigidBody2D"]
+script = ExtResource("1_pw78o")
 
 [node name="PlayerShipSprite" type="Sprite2D" parent="."]
+rotation = 1.5708
 texture = ExtResource("1_f5d1k")
+
+[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="."]
+polygon = PackedVector2Array(37, -5, 37, 5, 23, 11, -22, 49, -29, 49, -30, 48, -30, 21, -38, 13, -38, -14, -30, -22, -30, -49, -21, -49, 23, -11)

--- a/scripts/input_manager.gd
+++ b/scripts/input_manager.gd
@@ -1,0 +1,8 @@
+class_name InputManager
+extends Node
+
+signal jumped
+
+func _input(event):
+	if(event.is_action_pressed("jump")):
+		jumped.emit()

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -1,0 +1,3 @@
+class_name Player
+extends RigidBody2D
+

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -1,3 +1,15 @@
 class_name Player
 extends RigidBody2D
 
+@export var jump_strength : int = 600
+
+var input_manager : InputManager
+
+func _ready():
+	input_manager = InputManager.new()
+	input_manager.jumped.connect(_on_jumped)
+	add_child(input_manager)
+
+func _on_jumped() -> void:
+	# Jump with a maximum velocity of jump_strength
+	self.linear_velocity.y = jump_strength * -1


### PR DESCRIPTION
## Summary

When you hit space, the player's up velocity is set. This prevents the player from going faster than their jump strength. This is subject to change in the future, depending on level design needs.

## Video

https://github.com/RGonzalezTech/SpaceTap/assets/13375474/39d5ad07-adfe-4168-ba65-43e5386c1c54