### PR TITLE
Add Build Action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: push
 
 env:
   GODOT_VERSION: 4.1
-  EXPORT_NAME: SpaceTap
+  EXPORT_NAME: index
   PROJECT_PATH: ./
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,3 +34,22 @@ jobs:
         with:
           name: web
           path: build/web
+
+  deploy:
+    name: Deploy to Itch.io
+    runs-on: ubuntu-20.04
+    needs: export
+    steps:
+      - name: Download Artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: web
+          path: build/web
+      - name: Upload to Itch.io
+        uses: manleydev/butler-publish-itchio-action@master
+        env:
+          BUTLER_CREDENTIALS: ${{ secrets.BUTLER_CREDENTIALS }}
+          CHANNEL: html
+          ITCH_GAME: spacetap
+          ITCH_USER: rgonzaleztech
+          PACKAGE: build/web

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,8 @@
 name: Build Project
 
-on: push
+on:
+  release:
+    types: [published]
 
 env:
   GODOT_VERSION: 4.1
@@ -25,6 +27,7 @@ jobs:
       - name: Setup Export Config
         run: |
           cp copy.export_presets.cfg export_presets.cfg
+          echo "${{ github.ref_name }}" > VERSION.txt
       - name: Web Build
         run: |
           mkdir -v -p build/web
@@ -49,6 +52,7 @@ jobs:
         uses: manleydev/butler-publish-itchio-action@master
         env:
           BUTLER_CREDENTIALS: ${{ secrets.BUTLER_CREDENTIALS }}
+          VERSION: ${{ github.ref_name }}
           CHANNEL: html
           ITCH_GAME: spacetap
           ITCH_USER: rgonzaleztech

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: Build Project
+
+on: push
+
+env:
+  GODOT_VERSION: 4.1
+  EXPORT_NAME: SpaceTap
+  PROJECT_PATH: ./
+
+jobs:
+  export:
+    name: Web Export
+    runs-on: ubuntu-20.04
+    container:
+      image: barichello/godot-ci:4.1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          lfs: true
+      - name: Setup Godot
+        run: |
+          mkdir -v -p ~/.local/share/godot/export_templates/
+          mv /root/.local/share/godot/export_templates/${GODOT_VERSION}.stable ~/.local/share/godot/export_templates/${GODOT_VERSION}.stable
+      - name: Setup Export Config
+        run: |
+          cp copy.export_presets.cfg export_presets.cfg
+      - name: Web Build
+        run: |
+          mkdir -v -p build/web
+          godot --headless --verbose --export-release "Itch.io Web Build" ./build/web/$EXPORT_NAME.html
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: web
+          path: build/web

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # Build files
 export_presets.cfg
 build/
+VERSION.txt
 
 # GUT editor
 .gut_editor_config.json

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .godot/
 
 # Build files
+export_presets.cfg
 build/
 
 # GUT editor

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # Godot 4+ specific ignores
 .godot/
 
+# Build files
+build/
+
 # GUT editor
 .gut_editor_config.json

--- a/copy.export_presets.cfg
+++ b/copy.export_presets.cfg
@@ -1,0 +1,36 @@
+[preset.0]
+
+name="Itch.io Web Build"
+platform="Web"
+runnable=true
+dedicated_server=false
+custom_features=""
+export_filter="all_resources"
+include_filter=""
+exclude_filter=""
+encryption_include_filters=""
+encryption_exclude_filters=""
+encrypt_pck=false
+encrypt_directory=false
+
+[preset.0.options]
+
+custom_template/debug=""
+custom_template/release=""
+variant/extensions_support=false
+vram_texture_compression/for_desktop=true
+vram_texture_compression/for_mobile=false
+html/export_icon=true
+html/custom_html_shell=""
+html/head_include=""
+html/canvas_resize_policy=2
+html/focus_canvas_on_start=true
+html/experimental_virtual_keyboard=false
+progressive_web_app/enabled=false
+progressive_web_app/offline_page=""
+progressive_web_app/display=1
+progressive_web_app/orientation=0
+progressive_web_app/icon_144x144=""
+progressive_web_app/icon_180x180=""
+progressive_web_app/icon_512x512=""
+progressive_web_app/background_color=Color(0, 0, 0, 1)

--- a/project.godot
+++ b/project.godot
@@ -11,6 +11,7 @@ config_version=5
 [application]
 
 config/name="Space Tap"
+run/main_scene="res://scenes/levels/PlaceholderScene.tscn"
 config/features=PackedStringArray("4.1", "GL Compatibility")
 config/icon="res://icon.svg"
 
@@ -23,6 +24,11 @@ enabled=PackedStringArray("res://addons/gut/plugin.cfg")
 jump={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":32,"key_label":0,"unicode":32,"echo":false,"script":null)
+]
+}
+reset={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":82,"key_label":0,"unicode":114,"echo":false,"script":null)
 ]
 }
 

--- a/project.godot
+++ b/project.godot
@@ -15,6 +15,10 @@ run/main_scene="res://scenes/levels/PlaceholderScene.tscn"
 config/features=PackedStringArray("4.1", "GL Compatibility")
 config/icon="res://icon.svg"
 
+[autoload]
+
+DebugUi="*res://scenes/autoload/debug/DebugUI.tscn"
+
 [editor_plugins]
 
 enabled=PackedStringArray("res://addons/gut/plugin.cfg")

--- a/scenes/autoload/debug/DebugUI.tscn
+++ b/scenes/autoload/debug/DebugUI.tscn
@@ -1,0 +1,27 @@
+[gd_scene load_steps=2 format=3 uid="uid://c5pox41uahp6w"]
+
+[ext_resource type="Script" path="res://scenes/autoload/debug/VersionLabel.gd" id="1_qe4tx"]
+
+[node name="DebugUI" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="DebugCanvas" type="CanvasLayer" parent="."]
+
+[node name="VersionLabel" type="Label" parent="DebugCanvas"]
+anchors_preset = 1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -125.0
+offset_top = 16.0
+offset_right = -16.0
+offset_bottom = 42.0
+grow_horizontal = 0
+text = "Version: NULL"
+horizontal_alignment = 2
+vertical_alignment = 1
+script = ExtResource("1_qe4tx")

--- a/scenes/autoload/debug/VersionLabel.gd
+++ b/scenes/autoload/debug/VersionLabel.gd
@@ -1,0 +1,5 @@
+extends Label
+
+func _ready():
+	var version = DebugInfo.get_version()
+	self.text = version

--- a/scenes/levels/PlaceholderScene.tscn
+++ b/scenes/levels/PlaceholderScene.tscn
@@ -1,0 +1,66 @@
+[gd_scene load_steps=4 format=3 uid="uid://bpki4rwafrls7"]
+
+[ext_resource type="PackedScene" uid="uid://cbo0qhc8xyn3p" path="res://scenes/PlayerShip.tscn" id="1_h0aj4"]
+[ext_resource type="PackedScene" uid="uid://bqt46q61uyt5p" path="res://scenes/obstacles/MovingMeteor.tscn" id="2_qiu1d"]
+
+[sub_resource type="GDScript" id="GDScript_eiy2y"]
+resource_name = "Listener"
+script/source = "extends Node
+
+func _reset_scene():
+	get_tree().change_scene_to_file(\"res://scenes/levels/PlaceholderScene.tscn\")
+
+func _on_player_ship_root_died(obstacle):
+	print(\"Player, Died!\")
+	_reset_scene()
+
+func _input(event):
+	if event.is_action_pressed(\"reset\"):
+		print(\"Resetting\")
+		get_viewport().set_input_as_handled()
+		_reset_scene()
+"
+
+[node name="PlaceholderScene" type="Node2D"]
+
+[node name="PlayerShipRoot" parent="." instance=ExtResource("1_h0aj4")]
+position = Vector2(206, 131)
+
+[node name="MeteorRoot" parent="." instance=ExtResource("2_qiu1d")]
+position = Vector2(1041, 232)
+speed = 500.0
+
+[node name="MeteorRoot2" parent="." node_paths=PackedStringArray("tail_area") instance=ExtResource("2_qiu1d")]
+position = Vector2(1315, 387)
+speed = 500.0
+tail_area = NodePath("../MeteorRoot/TailLine")
+
+[node name="MeteorRoot3" parent="." node_paths=PackedStringArray("tail_area") instance=ExtResource("2_qiu1d")]
+position = Vector2(1492, 88)
+speed = 500.0
+tail_area = NodePath("../MeteorRoot/TailLine")
+
+[node name="MeteorRoot4" parent="." node_paths=PackedStringArray("tail_area") instance=ExtResource("2_qiu1d")]
+position = Vector2(1623, 557)
+speed = 500.0
+tail_area = NodePath("../MeteorRoot/TailLine")
+
+[node name="MeteorRoot5" parent="." node_paths=PackedStringArray("tail_area") instance=ExtResource("2_qiu1d")]
+position = Vector2(1668, 473)
+speed = 500.0
+tail_area = NodePath("../MeteorRoot/TailLine")
+
+[node name="MeteorRoot6" parent="." node_paths=PackedStringArray("tail_area") instance=ExtResource("2_qiu1d")]
+position = Vector2(1725, 365)
+speed = 500.0
+tail_area = NodePath("../MeteorRoot/TailLine")
+
+[node name="MeteorRoot7" parent="." node_paths=PackedStringArray("tail_area") instance=ExtResource("2_qiu1d")]
+position = Vector2(1927, 111)
+speed = 500.0
+tail_area = NodePath("../MeteorRoot/TailLine")
+
+[node name="Listener" type="Node" parent="."]
+script = SubResource("GDScript_eiy2y")
+
+[connection signal="died" from="PlayerShipRoot" to="Listener" method="_on_player_ship_root_died"]

--- a/scripts/debug/debug_info.gd
+++ b/scripts/debug/debug_info.gd
@@ -1,0 +1,11 @@
+class_name DebugInfo
+extends Object
+
+static func get_version() -> String:
+	var version_file_path = "res://VERSION.txt"
+	var version_exists = FileAccess.file_exists(version_file_path)
+	
+	if(version_exists):
+		return FileAccess.get_file_as_string(version_file_path)
+	else:
+		return "VERSION.txt not found"


### PR DESCRIPTION
## Summary

Created a github workflow that will build the game as an HTML export and then upload it to Itch.IO. This workflow is triggered when we publish a new release. When the release is published, we use the tag name (`v0.1.0`) as `res://VERSION.txt`. Then, the value in that file is used to display the current build/version in the Debug UI autoload scene.

I also created a Placeholder scene that has the player and some moving meteors. If you press `r`, then the scene reloads itself. It's just to make sure that the game is being exported in a playable state.