### PR TITLE
Bugfix: Rigidbody collision was inconsistent. 

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run unit tests
-        uses: croconut/godot-tester@v5
+        uses: croconut/godot-tester@v5.1
         with:
           # required
           version: "4.1"

--- a/scripts/obstacles/moving_obstacle.gd
+++ b/scripts/obstacles/moving_obstacle.gd
@@ -23,7 +23,12 @@ func _physics_process(delta: float):
 ## This function moves the obstacle in the direction specified by the `direction` variable.
 ## You can overwrite this function to add custom behavior to the obstacle's movement.
 func _move_obstacle(delta: float) -> void:
-	var _collision = move_and_collide(direction * speed * delta)
+	var collision = move_and_collide(direction * speed * delta)
+	if !collision:
+		return
+	var obj = collision.get_collider()
+	if obj is Player:
+		(obj as Player).die(self)
 
 func _on_tail_enter(area: Area2D) -> void:
 	if area is LevelBoundary:

--- a/scripts/player/player.gd
+++ b/scripts/player/player.gd
@@ -25,13 +25,17 @@ var input_manager : InputManager
 ## This object is created on ready.
 var score_manager : ScoreManager
 
+## This function is called by the Obstacle when it collides with the player.
+## It emits the "died" signal with the obstacle that was passed as an argument.
+func die(obstacle: BaseObstacle) -> void:
+	died.emit(obstacle)
+
 ## This function will pass the points to the [ScoreManager] to increase the score
 func add_points(points: int) -> void:
 	score_manager.increase_score(points)
 
 func _ready():
 	_subscribe_to_inputs()
-	_subscribe_to_physics()
 	_subscribe_to_score()
 
 # Private methods
@@ -47,19 +51,9 @@ func _subscribe_to_score() -> void:
 		score_manager.score_changed.connect(score_ui.set_score)
 	add_child(score_manager)
 
-func _subscribe_to_physics() -> void:
-	self.max_contacts_reported = 1
-	self.contact_monitor = true
-	self.body_entered.connect(_on_body_entered)
-
 # Listeners
 # This function is called when the player's input manager emits the "jumped" signal.
 # It sets the player's y velocity to the jump_strength
 func _on_jumped() -> void:
 	# Negative y velocity to jump "up"
 	self.linear_velocity.y = jump_strength * -1
-
-# This function is called when the player touches a physics body. If the body is an obstacle, the player dies
-func _on_body_entered(body: Node) -> void:
-	if body is BaseObstacle:
-		died.emit(body)

--- a/test/player/test_player.gd
+++ b/test/player/test_player.gd
@@ -61,7 +61,7 @@ class TestPhysics:
 		add_child_autofree(obstacle)
 
 		assert_signal_not_emitted(player, "died")
-		player.body_entered.emit(obstacle)
+		player.die(obstacle)
 		assert_signal_emitted(player, "died")
 
 	func test_does_not_emit_died_on_touching_other():


### PR DESCRIPTION
## Summary

I was noticing that the player would occasionally collide with a meteor but it was not triggering a "Died" event. After some reading, it seems like `Rigidbody2D` might not be the best at detecting collisions. So, I removed collision detection from the player and exposed a `.die(obstacle)` function so that the obstacle (which is a `CharacterBody2D`) can handle the collision and inform the player that they have died.